### PR TITLE
Create WorkOnAppleSilicon.md

### DIFF
--- a/WorkOnAppleSilicon.md
+++ b/WorkOnAppleSilicon.md
@@ -1,0 +1,22 @@
+# Apple Silicon Compatibility
+
+I was able to run this easily on an M3 Macbook Pro by making the following changes. I don't know if there is a way to alter the yaml file dynamically and when I tried to add any parameters I got a Pydantic error, because extras were forbidden.
+
+## train.py
+
+Change device setup to read:
+
+`
+  device = "mps" if torch.mps.is_available() else "cpu"
+`
+
+## config.yaml
+
+Changed training arguments:
+
+`
+  batch_size: 16         # (Not sure if this was necessary, was suggested by Grok)
+  optim:"adamw_torch"    # fused not supported on mps
+  tf32: false
+  bf16: false
+`


### PR DESCRIPTION
This file explains how I was able to run on Apple Silicon - I suggest that you make these changes with the necessary code logic so that the tool will automatically work with Mac.  This is an extremely COOL pipeline that you have built.

Created two branches because I am not expert - there is no difference between them.